### PR TITLE
Fix signature form layout issue

### DIFF
--- a/core/participant.py
+++ b/core/participant.py
@@ -1811,7 +1811,6 @@ class ParticipantSignatureForm( Form ):
 		self.helper = FormHelper( self )
 		self.helper.form_action = '.'
 		self.helper.form_id = 'id_signature_form'
-		self.helper.form_class = 'navbar-form navbar-left'
 		
 		if is_jsignature:
 			button_args = [
@@ -1827,24 +1826,20 @@ class ParticipantSignatureForm( Form ):
 		
 		if is_jsignature:
 			self.helper.layout = Layout(
-				Container(
-					Row( Col(Field('signature'), 12) ),
-					Row( Col(Div(id="id_signature_canvas"), 12) ),
-
-					Row(
-						Col(button_args[0],4),
-						Col(button_args[1],4),
-						Col(button_args[2],4),
-					),
-				)
+				Row( Col(Field('signature'), 12) ),
+				Row( Col(Div(id="id_signature_canvas"), 12) ),
+				Row(
+					Col(button_args[0],4),
+					Col(button_args[1],4),
+					Col(button_args[2],4),
+				),
 			)
 		else:
 			self.helper.layout = Layout(
-				Container(
 					Row( Col( Field( 'signature' ), 12) ),
 					Row( Div( Div(*button_args, css_class='row'), css_class='col-md-12 text-center' ) ),
 				)
-			)
+			
 
 @access_validation()
 def ParticipantSignatureChange( request, participantId ):

--- a/core/templates/participant_jsignature_change.html
+++ b/core/templates/participant_jsignature_change.html
@@ -66,7 +66,9 @@ function reset_signature() {
 	<strong>{{participant.license_holder.date_of_birth|date_short}}</strong>.
 {% endif %}
 </h2>
-{% crispy form %}
+<div class="container">
+	{% crispy form %}
+</div>
 <div class="container hidden-print">
 	<div class="row">
 		<div class="col-md-12 text-right">

--- a/core/templates/participant_signature_change.html
+++ b/core/templates/participant_signature_change.html
@@ -50,8 +50,9 @@
 {% endif %}
 </h2>
 <hr/>
-{% crispy form %}
-<p/>
+<div class="container">
+	{% crispy form %}
+</div>
 <div class="row hidden-print">
 	<div class="col-md-12 text-right">
 		<a class="btn btn-primary" href="./SetSignatureWithTouchScreen/1/">{% trans "Get Signature with Touch Screen" %}</a>

--- a/core/templates/self_serve_signature.html
+++ b/core/templates/self_serve_signature.html
@@ -67,5 +67,7 @@ function reset_signature() {
 	<strong>{{participant.license_holder.date_of_birth}}</strong>.
 {% endif %}
 </h2>
-{% crispy form %}
+<div class="container">
+	{% crispy form %}
+</div>
 {% endblock content %}


### PR DESCRIPTION
On some responsive widths, touch input is not focused to the signature canvas as the container div for the pen input overlays for form element. Moving the container element outside of the form element fixes the layout issue so they stack under eachother.